### PR TITLE
Add logo and customer fields

### DIFF
--- a/MSP Pricing Calculator/MSP_Pricing_CalculatorApp.swift
+++ b/MSP Pricing Calculator/MSP_Pricing_CalculatorApp.swift
@@ -11,7 +11,9 @@ import SwiftUI
 struct MSP_Pricing_CalculatorApp: App {
     var body: some Scene {
         WindowGroup {
-            QuoteFormView()
+            NavigationStack {
+                QuoteFormView()
+            }
         }
     }
 }

--- a/MSP Pricing Calculator/QuoteFormView.swift
+++ b/MSP Pricing Calculator/QuoteFormView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 private let intFormatter: NumberFormatter = {
     let f = NumberFormatter()
@@ -8,9 +9,36 @@ private let intFormatter: NumberFormatter = {
 
 struct QuoteFormView: View {
     @StateObject private var viewModel = QuoteViewModel()
+    @State private var logoItem: PhotosPickerItem?
 
     var body: some View {
         Form {
+            // ── Company / Customer ─────────────────────────────────────
+            Section(header: Text("Info")) {
+                TextField("Company Name", text: $viewModel.companyName)
+                TextField("Customer Name", text: $viewModel.customerName)
+
+                PhotosPicker(selection: $logoItem, matching: .images) {
+                    if let image = viewModel.logoImage {
+                        Image(uiImage: image)
+                            .resizable()
+                            .frame(width: 60, height: 60)
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
+                    } else {
+                        Text("Select Logo")
+                    }
+                }
+                .onChange(of: logoItem) { newItem in
+                    guard let newItem else { return }
+                    Task {
+                        if let data = try? await newItem.loadTransferable(type: Data.self),
+                           let img = UIImage(data: data) {
+                            viewModel.logoImage = img
+                        }
+                    }
+                }
+            }
+
             // ── Device counts ─────────────────────────────────────────────
             Section(header: Text("Devices")) {
 
@@ -43,6 +71,22 @@ struct QuoteFormView: View {
                             .keyboardType(.numberPad)
                     }
                 }
+
+                Stepper(value: $viewModel.numCameras, in: 0...1000) {
+                    HStack {
+                        Text("Cameras")
+                        Spacer()
+                        TextField("", value: $viewModel.numCameras, formatter: intFormatter)
+                            .multilineTextAlignment(.trailing)
+                            .keyboardType(.numberPad)
+                    }
+                }
+
+                Picker("NVR", selection: $viewModel.selectedNvr) {
+                    ForEach(0..<viewModel.nvrOptions.count, id: \.self) { idx in
+                        Text(viewModel.nvrOptions[idx]).tag(idx)
+                    }
+                }
             }
 
             // ── Add-ons ───────────────────────────────────────────────────
@@ -50,6 +94,8 @@ struct QuoteFormView: View {
                 Toggle("Server Backup",       isOn: $viewModel.includeServerBackup)
                 Toggle("Workstation Backup",  isOn: $viewModel.includeWSBackup)
                 Toggle("Advanced Email Security", isOn: $viewModel.includeEmailSec)
+                Toggle("Huntress Cybersecurity", isOn: $viewModel.includeHuntress)
+                Toggle("Webroot Cybersecurity",  isOn: $viewModel.includeWebroot)
             }
 
             // ── Total ─────────────────────────────────────────────────────
@@ -59,6 +105,9 @@ struct QuoteFormView: View {
                     Text("Total: \(viewModel.total, format: .currency(code: Locale.current.currency?.identifier ?? "USD"))")
                         .bold()
                     Spacer()
+                }
+                if let pdfURL = viewModel.generatePDF() {
+                    ShareLink("Download Quote", item: pdfURL)
                 }
             }
         }

--- a/MSP Pricing Calculator/QuoteViewModel.swift
+++ b/MSP Pricing Calculator/QuoteViewModel.swift
@@ -1,13 +1,26 @@
 import Foundation
 import Combine
+import UIKit
+import SwiftUI
 
 class QuoteViewModel: ObservableObject {
     @Published var numServers: Int = 0
     @Published var numWorkstations: Int = 0
     @Published var numEmailAccounts: Int = 0
+    @Published var numCameras: Int = 0
+    @Published var selectedNvr: Int = 0 // 0:none,1:8,2:16,3:32,4:64
     @Published var includeServerBackup: Bool = false
     @Published var includeWSBackup: Bool = false
     @Published var includeEmailSec: Bool = false
+    @Published var includeHuntress: Bool = false
+    @Published var includeWebroot: Bool = false
+
+    // Branding
+    @Published var companyName: String = ""
+    @Published var customerName: String = ""
+    @Published var logoImage: UIImage?
+
+    let nvrOptions = ["None", "8 Port", "16 Port", "32 Port", "64 Port"]
 
     private let config: PricingConfig
 
@@ -34,6 +47,82 @@ class QuoteViewModel: ObservableObject {
             value += Double(numEmailAccounts) * price(for: "email_sec")
         }
 
+        if includeHuntress {
+            value += Double(numWorkstations) * price(for: "huntress")
+        }
+        if includeWebroot {
+            value += Double(numWorkstations) * price(for: "webroot")
+        }
+
+        switch selectedNvr {
+        case 1: value += price(for: "nvr_8")
+        case 2: value += price(for: "nvr_16")
+        case 3: value += price(for: "nvr_32")
+        case 4: value += price(for: "nvr_64")
+        default: break
+        }
+
+        value += Double(numCameras) * price(for: "camera")
+
         return value
+    }
+
+    func generatePDF() -> URL? {
+        let renderer = UIGraphicsPDFRenderer(bounds: CGRect(x: 0, y: 0, width: 612, height: 792))
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("quote.pdf")
+        do {
+            try renderer.writePDF(to: url) { ctx in
+                ctx.beginPage()
+                let name = companyName.isEmpty ? "My Company" : companyName
+                let title = "\(name) Quote"
+                let paragraphStyle = NSMutableParagraphStyle()
+                paragraphStyle.alignment = .center
+                let attrs: [NSAttributedString.Key: Any] = [
+                    .font: UIFont.boldSystemFont(ofSize: 24),
+                    .paragraphStyle: paragraphStyle
+                ]
+                var top: CGFloat = 40
+                if let logo = logoImage {
+                    logo.draw(in: CGRect(x: 40, y: 20, width: 80, height: 80))
+                    top = 110
+                }
+                title.draw(in: CGRect(x: 0, y: top, width: 612, height: 30), withAttributes: attrs)
+
+                let formatter = DateFormatter()
+                formatter.dateStyle = .medium
+                formatter.timeStyle = .short
+                let dateStr = formatter.string(from: Date())
+                var currentY = top + 40
+                ("Generated: \(dateStr)" as NSString).draw(at: CGPoint(x: 40, y: currentY), withAttributes: [.font: UIFont.systemFont(ofSize: 14)])
+                currentY += 20
+                if !customerName.isEmpty {
+                    ("Customer: \(customerName)" as NSString).draw(at: CGPoint(x: 40, y: currentY), withAttributes: [.font: UIFont.systemFont(ofSize: 14)])
+                }
+
+                var y = Double(currentY + 40)
+                func draw(_ text: String) {
+                    (text as NSString).draw(at: CGPoint(x: 40, y: y), withAttributes: [.font: UIFont.systemFont(ofSize: 14)])
+                    y += 20
+                }
+
+                draw("Servers: \(numServers)")
+                draw("Workstations: \(numWorkstations)")
+                draw("Email Accounts: \(numEmailAccounts)")
+                draw("Cameras: \(numCameras)")
+                if selectedNvr > 0 { draw("NVR: \(nvrOptions[selectedNvr])") }
+                if includeServerBackup { draw("Server Backup: Yes") }
+                if includeWSBackup { draw("Workstation Backup: Yes") }
+                if includeEmailSec { draw("Advanced Email Security: Yes") }
+                if includeHuntress { draw("Huntress Cybersecurity: Yes") }
+                if includeWebroot { draw("Webroot Cybersecurity: Yes") }
+
+                y += 20
+                let totalStr = String(format: "Total: $%.2f", total)
+                (totalStr as NSString).draw(at: CGPoint(x: 40, y: y), withAttributes: [.font: UIFont.boldSystemFont(ofSize: 16)])
+            }
+            return url
+        } catch {
+            return nil
+        }
     }
 }

--- a/MSP Pricing Calculator/pricing.json
+++ b/MSP Pricing Calculator/pricing.json
@@ -4,6 +4,16 @@
     { "code": "base_ws",      "name": "Workstation Support",     "unitPrice": 25  },
     { "code": "bkup_server",  "name": "Server Cloud Backup",     "unitPrice": 55  },
     { "code": "bkup_ws",      "name": "Workstation Cloud Backup","unitPrice": 16  },
-    { "code": "email_sec",    "name": "Advanced Email Security", "unitPrice": 8   }
+    { "code": "email_sec",    "name": "Advanced Email Security", "unitPrice": 8   },
+
+    { "code": "huntress",    "name": "Huntress Cybersecurity",      "unitPrice": 6   },
+    { "code": "webroot",     "name": "Webroot Cybersecurity",       "unitPrice": 4   },
+
+    { "code": "nvr_8",       "name": "NVR 8-Port",                  "unitPrice": 250 },
+    { "code": "nvr_16",      "name": "NVR 16-Port",                 "unitPrice": 350 },
+    { "code": "nvr_32",      "name": "NVR 32-Port",                 "unitPrice": 550 },
+    { "code": "nvr_64",      "name": "NVR 64-Port",                 "unitPrice": 750 },
+
+    { "code": "camera",      "name": "Security Camera",             "unitPrice": 120 }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A lightweight SwiftUI iOS application that lets Managed‑Service Providers (MSP
 * **MVVM architecture** – clearly separated *Models*, *ViewModels*, *Views*.
 * **SwiftUI previews** – tweak UI in real time with `#Preview` providers.
 * **iCloud‑ready** – point the JSON loader to a remote URL to update prices over‑the‑air.
+* **Branded PDF quotes** – include your logo, company and customer names in an exported PDF.
 
 ---
 
@@ -36,6 +37,7 @@ $ open MSP\ Pricing\ Calculator.xcodeproj
 
 1. Select an **iPhone simulator** (e.g. *iPhone 16 Pro*).
 2. Press **⌘R**. The quote form appears with default pricing.
+3. In the **Info** section of the form, provide your company and customer names and pick a logo image. These details appear in the downloaded quote.
 
 ---
 
@@ -50,7 +52,14 @@ $ open MSP\ Pricing\ Calculator.xcodeproj
     { "code": "base_ws",      "name": "Workstation Support",      "unitPrice": 25  },
     { "code": "bkup_server",  "name": "Server Cloud Backup",       "unitPrice": 55  },
     { "code": "bkup_ws",      "name": "Workstation Cloud Backup",  "unitPrice": 16  },
-    { "code": "email_sec",    "name": "Advanced Email Security",   "unitPrice": 8   }
+    { "code": "email_sec",    "name": "Advanced Email Security",   "unitPrice": 8   },
+    { "code": "huntress",    "name": "Huntress Cybersecurity",      "unitPrice": 6   },
+    { "code": "webroot",     "name": "Webroot Cybersecurity",       "unitPrice": 4   },
+    { "code": "nvr_8",       "name": "NVR 8-Port",                  "unitPrice": 250 },
+    { "code": "nvr_16",      "name": "NVR 16-Port",                 "unitPrice": 350 },
+    { "code": "nvr_32",      "name": "NVR 32-Port",                 "unitPrice": 550 },
+    { "code": "nvr_64",      "name": "NVR 64-Port",                 "unitPrice": 750 },
+    { "code": "camera",      "name": "Security Camera",             "unitPrice": 120 }
   ]
 }
 ```


### PR DESCRIPTION
## Summary
- allow picking a logo image and entering company/customer names
- display those fields in generated PDF quotes
- highlight new feature in README
- document how to add the logo in the app

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6843c76219188333aeaab4883f75ddb0